### PR TITLE
added 3-Clause BSD license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,30 @@
+Copyright (c) 2014-2017, Beibei Chen
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials provided
+       with the distribution.
+
+    * Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Requirement:
 -  Perl 5 and above;
 -  Python packages: pysam;
 -  R packages: MASS,VGAM and their dependencies.
+-  pybedtools
+-  rpy2
 -  Other packages: HOMER and annotation files
 
 
@@ -33,5 +35,9 @@ How to use:
 - -M FDR to get significant mutations
 - -C FDR to get enriched clusters
 - -s species 
+
+License
+=======
+PIPE-CLIP can be distributed and modifed under the 3-Clause BSD License. See LICENSE.txt for more information.
 
 Contact: mins.kim@utsouthwestern.edu


### PR DESCRIPTION
PIPE-CLIP seemed to be available under 3-clause BSD on [google code](
https://code.google.com/archive/p/pipe-clip/). The code on github does not have any licensing information. This makes working with the code legally problematic.

- I added a copy of the 3-clause BSD.
- I also added pybedtools and rpy2 to the list of dependencies
